### PR TITLE
Wait for language initialization before rendering UI

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,10 +14,12 @@ import { ref, onMounted } from 'vue';
 import { useApiStore } from '@/stores/apiStore';
 import { usePlannerStore } from '@/stores/plannerStore';
 import { useUserStore } from '@/stores/userStore';
+import { useLanguageStore } from '@/stores/languageStore';
 
 const apiStore = useApiStore();
 const plannerStore = usePlannerStore();
 const userStore = useUserStore();
+const languageStore = useLanguageStore();
 const sessionReady = ref(false);
 const MIN_RECIPE_SUGGESTIONS =
   parseInt(import.meta.env.VITE_MIN_RECIPE_SUGGESTIONS) || 5;
@@ -41,9 +43,11 @@ onMounted(async () => {
     return await apiStore.createSession();
   };
 
-  const sessionEstablished = await ensureSession();
+  const [sessionEstablished] = await Promise.all([
+    ensureSession(),
+    languageStore.initLocale(),
+  ]);
 
-  // Mark session ready immediately to render the app UI
   sessionReady.value = true;
 
   // Fetch suggestions in the background to avoid blocking initial render


### PR DESCRIPTION
## Summary
- expose locale initialization state in the language store so translations load deterministically
- wait for language initialization before rendering the application shell to avoid untranslated placeholders

## Testing
- npm run lint *(fails: missing `@vue/eslint-config-typescript` required by eslint-config-vuetify)*

------
https://chatgpt.com/codex/tasks/task_e_68ee73144b688332a28a9000f7f920fd